### PR TITLE
some initial support for tuple syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -13,6 +13,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_parser = "0.1.5"
+cirru_parser = "0.1.6"
 lazy_static = "1.4.0"
 regex = "1.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -13,6 +13,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_parser = "0.1.6"
+cirru_parser = "0.1.7"
 lazy_static = "1.4.0"
 regex = "1.5.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,16 @@ fn extract_cirru_edn(node: &Cirru) -> Result<Edn, String> {
                 Err(String::from("missing edn do value"))
               }
             }
+            "::" => {
+              if xs.len() == 3 {
+                Ok(Edn::Tuple(
+                  Box::new(extract_cirru_edn(&xs[1])?),
+                  Box::new(extract_cirru_edn(&xs[2])?),
+                ))
+              } else {
+                Err(String::from("tuple expected 2 values"))
+              }
+            }
             "[]" => {
               let mut ys: Vec<Edn> = vec![];
               for (idx, x) in xs.iter().enumerate() {
@@ -226,6 +236,12 @@ fn assemble_cirru_node(data: &Edn) -> Cirru {
         ]));
       }
 
+      Cirru::List(ys)
+    }
+    Edn::Tuple(tag, v) => {
+      let mut ys: Vec<Cirru> = vec![Cirru::Leaf(String::from("::"))];
+      ys.push(assemble_cirru_node(&*tag.to_owned()));
+      ys.push(assemble_cirru_node(&*v.to_owned()));
       Cirru::List(ys)
     }
   }

--- a/tests/edn_tests.rs
+++ b/tests/edn_tests.rs
@@ -20,6 +20,14 @@ fn edn_parsing() {
 
   assert_eq!(Ok(Edn::Number(2.0)), cirru_edn::parse("do 2"));
   assert_eq!(Ok(Edn::Number(-2.2)), cirru_edn::parse("do -2.2"));
+
+  assert_eq!(
+    Ok(Edn::Tuple(
+      Box::new(Edn::Keyword(String::from("a"))),
+      Box::new(Edn::Number(1.0))
+    )),
+    cirru_edn::parse(":: :a 1")
+  );
 }
 
 #[test]
@@ -61,6 +69,14 @@ fn edn_formatting() -> Result<(), String> {
   assert_eq!(cirru_edn::format(&Edn::Keyword(String::from("a")), true)?, "\ndo :a\n");
   assert_eq!(cirru_edn::format(&Edn::Str(String::from("a")), true)?, "\ndo |a\n");
   assert_eq!(cirru_edn::format(&Edn::Str(String::from("a")), true)?, "\ndo |a\n");
+
+  assert_eq!(
+    cirru_edn::format(
+      &Edn::Tuple(Box::new(Edn::Keyword(String::from("a"))), Box::new(Edn::Number(1.0))),
+      true
+    )?,
+    "\n:: :a 1\n"
+  );
 
   Ok(())
 }


### PR DESCRIPTION
`:: :a b` syntax now used to represent a tuple. Normally we have `:: :quote $ demo code` formatted to `quote $ demo code`. But in some cases we also want tag of record being represented in Cirru EDN with data from Calcit Runner.
