### PR TITLE
rollback to str keyword for compatibility in dylibs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::fs;
 
-use cirru_edn;
 use cirru_edn::parse;
 
 fn criterion_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
Previously using `usize` for low memory footprint, however, it cannot be used inside dylibs, which generates ids in different orders.
