### PR TITLE
get edn fields in order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod primes;
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::iter::FromIterator;
 
 use cirru_parser::{Cirru, CirruWriterOptions};
 
@@ -208,7 +209,9 @@ fn assemble_cirru_node(data: &Edn) -> Cirru {
     Edn::Set(xs) => {
       let mut ys: Vec<Cirru> = Vec::with_capacity(xs.len() + 1);
       ys.push(Cirru::leaf("#{}"));
-      for x in xs {
+      let mut items = xs.iter().collect::<Vec<_>>();
+      items.sort();
+      for x in items {
         ys.push(assemble_cirru_node(x));
       }
       Cirru::List(ys)
@@ -216,7 +219,9 @@ fn assemble_cirru_node(data: &Edn) -> Cirru {
     Edn::Map(xs) => {
       let mut ys: Vec<Cirru> = Vec::with_capacity(xs.len() + 1);
       ys.push(Cirru::leaf("{}"));
-      for (k, v) in xs {
+      let mut items = Vec::from_iter(xs.iter());
+      items.sort();
+      for (k, v) in items {
         ys.push(Cirru::List(vec![assemble_cirru_node(k), assemble_cirru_node(v)]))
       }
       Cirru::List(ys)
@@ -254,7 +259,7 @@ fn assemble_cirru_node(data: &Edn) -> Cirru {
   }
 }
 
-/// generate string fro, Edn
+/// generate string from Edn
 pub fn format(data: &Edn, use_inline: bool) -> Result<String, String> {
   let options = CirruWriterOptions { use_inline };
   match assemble_cirru_node(data) {

--- a/tests/edn_tests.rs
+++ b/tests/edn_tests.rs
@@ -1,4 +1,4 @@
-use cirru_edn::{Edn, EdnKwd};
+use cirru_edn::{self, Edn, EdnKwd};
 use cirru_parser::Cirru;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -249,5 +249,35 @@ fn test_buffer() -> Result<(), String> {
     String::from("buf 0a")
   );
 
+  Ok(())
+}
+
+#[test]
+fn test_string_order() -> Result<(), String> {
+  let mut data: HashMap<Edn, Edn> = HashMap::new();
+  data.insert(Edn::kwd("a"), Edn::Number(1.0));
+  data.insert(Edn::kwd("c"), Edn::Number(2.0));
+  data.insert(Edn::kwd("b"), Edn::Number(3.0));
+  data.insert(Edn::kwd("Z"), Edn::Number(4.0));
+  assert_eq!(
+    cirru_edn::format(&Edn::Map(data), true).unwrap().trim(),
+    "{} (:Z 4) (:a 1) (:b 3) (:c 2)".to_owned()
+  );
+
+  let mut data2: HashMap<Edn, Edn> = HashMap::new();
+  data2.insert(Edn::str("a"), Edn::Number(1.0));
+  data2.insert(Edn::str("c"), Edn::Number(2.0));
+  data2.insert(Edn::str("b"), Edn::Number(3.0));
+  data2.insert(Edn::str("Z"), Edn::Number(4.0));
+  assert_eq!(
+    cirru_edn::format(&Edn::Map(data2), true).unwrap().trim(),
+    "{} (|Z 4) (|a 1) (|b 3) (|c 2)".to_owned()
+  );
+
+  let mut v: HashSet<Edn> = HashSet::new();
+  v.insert(Edn::kwd("a"));
+  v.insert(Edn::kwd("1"));
+  v.insert(Edn::kwd("z"));
+  assert_eq!(Ok(Edn::Set(v)), cirru_edn::parse("#{} :z :a :1"));
   Ok(())
 }


### PR DESCRIPTION
current request is calcit generating stable `compact.cirru` file when content modified randomly.