### PR TITLE
chore: release 0.7.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_parser = "0.2.4"
+cirru_parser = "0.2.5"
 # cirru_parser = { path = "../parser.rs" }
 hex = "0.4.3"
 cjk = "0.2.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,10 +353,8 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                 }
                 let mut child_path = path.clone();
                 child_path.push(i);
-                match extract_cirru_edn_with_path(x, child_path) {
-                  Ok(v) => ys.push(v),
-                  Err(v) => return Err(v),
-                }
+                let v = extract_cirru_edn_with_path(x, child_path)?;
+                ys.push(v);
               }
               Ok(Edn::List(EdnListView(ys)))
             }
@@ -369,12 +367,8 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                 }
                 let mut child_path = path.clone();
                 child_path.push(i);
-                match extract_cirru_edn_with_path(x, child_path) {
-                  Ok(v) => {
-                    ys.insert(v);
-                  }
-                  Err(v) => return Err(v),
-                }
+                let v = extract_cirru_edn_with_path(x, child_path)?;
+                ys.insert(v);
               }
               Ok(Edn::Set(EdnSetView(ys)))
             }

--- a/tests/edn_tests.rs
+++ b/tests/edn_tests.rs
@@ -179,7 +179,8 @@ fn set_writing() -> Result<(), String> {
 }
 
 const RECORD_DEMO: &str = r#"
-%{} :Demo (:a 1)
+%{} :Demo
+  :a 1
   :b 2
   :c $ [] 1 2 3
 "#;
@@ -394,7 +395,7 @@ fn test_format_record() -> Result<(), String> {
   });
   assert_eq!(
     cirru_edn::format(&record, true)?,
-    "\n%{} :Demo (:a 1) (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
+    "\n%{} :Demo\n  :a 1 (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
   );
 
   let record_unstable_order = Edn::Record(EdnRecordView {
@@ -412,7 +413,7 @@ fn test_format_record() -> Result<(), String> {
 
   assert_eq!(
     cirru_edn::format(&record_unstable_order, true)?,
-    "\n%{} :Demo (:a 1) (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
+    "\n%{} :Demo\n  :a 1 (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
   );
 
   Ok(())


### PR DESCRIPTION
Release 0.7.5 for cirru_parser 0.2.5 compatibility.

Changes:
- bump cirru_edn to 0.7.5
- update cirru_parser dependency to 0.2.5
- sync record-format test expectations with the updated writer output

Validation:
- cargo test
- cargo clippy --all-features -- -D warnings