### PR TITLE
release: 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See git history for changes in previous versions.
 
+## [0.7.9] - 2026-07-21
+
+### Changed
+
+- Upgrade `cirru_parser` to `0.2.13`, which adds `focus_cirru_preview` for
+  structurally folding large Cirru trees down to just the erroring path and
+  a few nearby siblings (instead of dumping the entire tree).
+- `EdnError::structure`/`EdnError::value` node previews now use
+  `focus_cirru_preview` + `cirru_parser::format` (indented, structural)
+  instead of a flat one-liner, so large snapshot files no longer flood error
+  output.
+- Added `EdnError::structure_focused` for cases where the path used for
+  structural folding differs from the path shown in the error header.
+- Added `EdnError::wrap_structure` to compose nested "invalid entry in X"
+  wrapper errors without re-embedding the inner error's full `Display` text
+  (avoids duplicated "Structure error at ..." headers and duplicated node
+  previews across nesting levels).
+
 ## [0.7.8] - 2026-07-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.21] - Previous versions
 
 See git history for changes in previous versions.
+
+## [0.7.8] - 2026-07-21
+
+### Changed
+
+- Format nested structure/value error paths as `@1.2.3.4`.
+- Correct error handling documentation to match the public `EdnError` API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_parser = "0.2.7"
+cirru_parser = "0.2.8"
 # cirru_parser = { path = "../parser.rs" }
 hex = "0.4.3"
 cjk = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.7.8"
+version = "0.7.9"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_parser = "0.2.8"
+cirru_parser = "0.2.13"
 # cirru_parser = { path = "../parser.rs" }
 hex = "0.4.3"
 cjk = "0.2.5"

--- a/README.md
+++ b/README.md
@@ -275,20 +275,14 @@ atom 1
 
 ### Error Handling (v0.7.0+)
 
-With cirru_parser 0.2.0, Cirru EDN provides enhanced error reporting with position information:
+With cirru_parser 0.2.0, Cirru EDN provides enhanced syntax-error reporting with source position information:
 
 ```rust
 use cirru_edn::{parse, EdnError};
 
 match parse("[] 1 2 invalid") {
     Ok(data) => println!("Parsed: {:?}", data),
-    Err(EdnError::ValueError { message, position }) => {
-        println!("Error: {}", message);
-        if let Some(pos) = position {
-            println!("  at line {}, column {}, byte {}",
-                     pos.line, pos.column, pos.offset);
-        }
-    }
+    Err(EdnError::ParseError { original }) => println!("Error: {}", original),
     Err(e) => println!("Other error: {}", e),
 }
 ```
@@ -299,6 +293,10 @@ Error types include:
 - `StructureError` - Invalid EDN structure
 - `ValueError` - Invalid values (e.g., bad hex, invalid tokens)
 - `DeserializationError` - Serde deserialization errors
+
+Structure and value errors include a nested Cirru path in `@1.2.3` notation; for example,
+`@1.2.3.4` means indices 1, 2, 3, and 4 from the root node. Syntax errors include
+line/column and byte-offset information when provided by the parser.
 
 See [ERROR_HANDLING.md](ERROR_HANDLING.md) for detailed documentation and examples.
 

--- a/examples/error_folding_demo.rs
+++ b/examples/error_folding_demo.rs
@@ -1,0 +1,88 @@
+//! Example: structural error folding in EDN parse errors.
+//!
+//! Demonstrates how [cirru_edn::parse] now folds large Cirru trees along the
+//! error path, showing only relevant siblings and collapsing irrelevant branches.
+
+use cirru_edn::parse;
+
+fn main() {
+  println!("=== EDN Error Folding Demo ===\n");
+
+  // ----------------------------------------------------------------
+  // Case 1: %{} record with malformed pair (triple instead of pair)
+  // ----------------------------------------------------------------
+  println!("── Case 1: %%{{}} record with a malformed (triple) pair ──\n");
+  let bad_record = r#"
+%{} :User
+  :age 30
+  (:name |Alice :extra |oops)
+  :active true
+"#;
+  match parse(bad_record) {
+    Ok(val) => println!("  Unexpected success: {val}"),
+    Err(e) => println!("{e}\n"),
+  }
+
+  // ----------------------------------------------------------------
+  // Case 2: Deeply nested %{} — folding siblings around the error
+  // ----------------------------------------------------------------
+  println!("── Case 2: nested record with error deep inside ──\n");
+  let deep_nested = r#"
+%{} :Package
+  :name |demo
+  :configs $ %{} :Config
+    :debug true
+    :port 8080
+    :entries $ %{} :Entry
+      :main $ %{} :Fn
+        :name |main
+        :args $ [] |x |y
+        (:body |x)
+      :reload $ %{} :Fn
+        :name |reload
+        :args $ []
+        :body |reload-body
+    :modules $ %{} :Module
+      :core $ %{} :Dep (:version |1.0 :extra) (:path |/lib)
+      :lib $ %{} :Dep
+        :version |2.0
+        :path |/lib2
+    :hooks $ %{} :Hooks
+      :start |start-hook
+      :stop |stop-hook
+  :version |1.0
+  :authors $ [] |Alice |Bob
+"#;
+  match parse(deep_nested) {
+    Ok(val) => println!("  Unexpected success: {val}"),
+    Err(e) => println!("{e}\n"),
+  }
+
+  // ----------------------------------------------------------------
+  // Case 3: Simple pair error — message body uses format_one_liner
+  // ----------------------------------------------------------------
+  println!("── Case 3: malformed pair inside a simple record ──\n");
+  let simple_pair = r#"
+%{} :Book
+  :title |Calcit
+  :pages (300 extra)
+  :author |Alice
+"#;
+  match parse(simple_pair) {
+    Ok(val) => println!("  Unexpected success: {val}"),
+    Err(e) => println!("{e}\n"),
+  }
+
+  // ----------------------------------------------------------------
+  // Case 4: List as record key — another {:?}→one-liner fix
+  // ----------------------------------------------------------------
+  println!("── Case 4: list used as record key ──\n");
+  let list_as_key = r#"
+%{} :Weird
+  ([] :oops) |bad
+"#;
+  match parse(list_as_key) {
+    Ok(val) => println!("  Unexpected success: {val}"),
+    Err(e) => println!("{e}\n"),
+  }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,9 @@ impl fmt::Display for Position {
   }
 }
 
-/// Format a nested Cirru path using the conventional `@1.2.3` notation.
+/// Format a nested Cirru path using the conventional `@1.2.3` notation,
+/// always absolute from the document root so it can be reliably parsed
+/// by tools/agents (never mixed with prose like "position N").
 fn format_path(path: &[usize]) -> String {
   let mut result = String::from("@");
   for (index, item) in path.iter().enumerate() {
@@ -109,37 +111,93 @@ impl EdnError {
     }
   }
 
-  /// Create a structure error with path and node preview
-  pub fn structure(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
-    let node_preview = node.and_then(|n| {
-      // Use one-liner format for cleaner, more readable output
-      cirru_parser::format_expr_one_liner(n).ok()
-    });
-    EdnError::StructureError {
-      message: message.into(),
-      path,
-      node_preview,
-    }
+/// Create a structure error with path and node preview, using `focus_path`
+/// for structural folding (relative to `node`) while `path` is used for display.
+pub fn structure_focused(
+  message: impl Into<String>,
+  path: Vec<usize>,
+  focus_path: &[usize],
+  node: Option<&Cirru>,
+) -> Self {
+  let node_preview = node.and_then(|n| {
+    let folded = cirru_parser::focus_cirru_preview(n, focus_path);
+    cirru_parser::format(std::slice::from_ref(&folded), false.into()).ok().map(|s| s.trim().to_string())
+  });
+  EdnError::StructureError {
+    message: message.into(),
+    path,
+    node_preview,
   }
+}
 
-  /// Create a value error with path and node preview
-  pub fn value(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
-    let node_preview = node.and_then(|n| {
-      // Use one-liner format for cleaner, more readable output
-      cirru_parser::format_expr_one_liner(n).ok()
-    });
-    EdnError::ValueError {
-      message: message.into(),
-      path,
-      node_preview,
-    }
+/// Create a structure error with path and node preview.
+/// The node is structurally folded along `path` before formatting.
+pub fn structure(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
+  let node_preview = node.and_then(|n| {
+    let folded = cirru_parser::focus_cirru_preview(n, &path);
+    cirru_parser::format(std::slice::from_ref(&folded), false.into()).ok().map(|s| s.trim().to_string())
+  });
+  EdnError::StructureError {
+    message: message.into(),
+    path,
+    node_preview,
   }
+}
+
+/// Create a value error with path and node preview.
+/// The node is structurally folded along `path` before formatting.
+pub fn value(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
+  let node_preview = node.and_then(|n| {
+    let folded = cirru_parser::focus_cirru_preview(n, &path);
+    cirru_parser::format(std::slice::from_ref(&folded), false.into()).ok().map(|s| s.trim().to_string())
+  });
+  EdnError::ValueError {
+    message: message.into(),
+    path,
+    node_preview,
+  }
+}
 
   /// Create a deserialization error with position
   pub fn deserialization(message: impl Into<String>, position: Option<Vec<u8>>) -> Self {
     EdnError::DeserializationError {
       message: message.into(),
       position,
+    }
+  }
+
+  /// Wrap an inner `EdnError` with a breadcrumb prefix describing the outer
+  /// context (e.g. which map key or record field it was found under),
+  /// WITHOUT re-formatting the inner error's own "Structure error at ..."
+  /// header. This keeps the final message to a single coordinate + a
+  /// readable breadcrumb trail, and reuses the innermost (most specific)
+  /// node preview instead of stacking multiple partial previews.
+  ///
+  /// The resulting error's `path` is the inner error's path when available
+  /// (already absolute from the document root), falling back to `fallback_path`
+  /// otherwise (e.g. when wrapping a `DeserializationError`).
+  pub fn wrap_structure(crumb: impl Into<String>, fallback_path: Vec<usize>, inner: &EdnError) -> Self {
+    let crumb = crumb.into();
+    match inner {
+      EdnError::StructureError {
+        message,
+        path,
+        node_preview,
+      }
+      | EdnError::ValueError {
+        message,
+        path,
+        node_preview,
+      } => EdnError::StructureError {
+        message: format!("{crumb}: {message}"),
+        path: path.clone(),
+        node_preview: node_preview.clone(),
+      },
+      other => EdnError::StructureError {
+        message: format!("{crumb}: {}", other.message()),
+        path: fallback_path,
+        node_preview: None,
+      },
     }
   }
 
@@ -169,9 +227,17 @@ impl fmt::Display for EdnError {
         if !path.is_empty() {
           write!(f, " at {}", format_path(path))?;
         }
-        write!(f, ": {message}")?;
+        write!(f, ": ")?;
+        for (i, line) in message.lines().enumerate() {
+          if i > 0 {
+            write!(f, "\n  ")?;
+          }
+          write!(f, "{line}")?;
+        }
         if let Some(preview) = node_preview {
-          write!(f, "\n  Node: {preview}")?;
+          for line in preview.lines() {
+            write!(f, "\n  {line}")?;
+          }
         }
         Ok(())
       }
@@ -184,9 +250,17 @@ impl fmt::Display for EdnError {
         if !path.is_empty() {
           write!(f, " at {}", format_path(path))?;
         }
-        write!(f, ": {message}")?;
+        write!(f, ": ")?;
+        for (i, line) in message.lines().enumerate() {
+          if i > 0 {
+            write!(f, "\n  ")?;
+          }
+          write!(f, "{line}")?;
+        }
         if let Some(preview) = node_preview {
-          write!(f, "\n  Node: {preview}")?;
+          for line in preview.lines() {
+            write!(f, "\n  {line}")?;
+          }
         }
         Ok(())
       }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,18 @@ impl fmt::Display for Position {
   }
 }
 
+/// Format a nested Cirru path using the conventional `@1.2.3` notation.
+fn format_path(path: &[usize]) -> String {
+  let mut result = String::from("@");
+  for (index, item) in path.iter().enumerate() {
+    if index > 0 {
+      result.push('.');
+    }
+    result.push_str(&item.to_string());
+  }
+  result
+}
+
 /// Errors that can occur during EDN parsing and manipulation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EdnError {
@@ -155,7 +167,7 @@ impl fmt::Display for EdnError {
       } => {
         write!(f, "Structure error")?;
         if !path.is_empty() {
-          write!(f, " at {path:?}")?;
+          write!(f, " at {}", format_path(path))?;
         }
         write!(f, ": {message}")?;
         if let Some(preview) = node_preview {
@@ -170,7 +182,7 @@ impl fmt::Display for EdnError {
       } => {
         write!(f, "Value error")?;
         if !path.is_empty() {
-          write!(f, " at {path:?}")?;
+          write!(f, " at {}", format_path(path))?;
         }
         write!(f, ": {message}")?;
         if let Some(preview) = node_preview {
@@ -190,6 +202,16 @@ impl From<&str> for EdnError {
     EdnError::ParseError {
       original: message.to_string(),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::format_path;
+
+  #[test]
+  fn formats_paths_with_at_and_dot_separators() {
+    assert_eq!(format_path(&[1, 2, 3, 4]), "@1.2.3.4");
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,9 @@ pub fn parse(s: &str) -> EdnResult<Edn> {
       Cirru::List(_) => extract_cirru_edn(&xs[0]),
     }
   } else {
+    let preview = cirru_parser::format_expr_one_liner(&Cirru::List(xs.to_vec())).unwrap_or_else(|_| "<expr>".into());
     Err(EdnError::structure(
-      format!("Expected 1 expr for edn, got length {}: {:?} ", xs.len(), xs),
+      format!("Expected 1 expr for edn, got length {}: {preview}", xs.len()),
       vec![],
       None,
     ))
@@ -403,18 +404,14 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                           zs.insert(k, v);
                         }
                         (Err(e), _) => {
-                          return Err(EdnError::structure(
-                            format!("invalid map entry `{}` from `{}`", e, ys[0]),
+                          return Err(EdnError::wrap_structure(
+                            format!("invalid map entry key `{}`", ys[0]),
                             k_path,
-                            Some(node),
+                            &e,
                           ));
                         }
                         (Ok(k), Err(e)) => {
-                          return Err(EdnError::structure(
-                            format!("invalid map entry for `{k}`, got {e}"),
-                            v_path,
-                            Some(node),
-                          ));
+                          return Err(EdnError::wrap_structure(format!("invalid map entry for `{k}`"), v_path, &e));
                         }
                       }
                     }
@@ -427,12 +424,13 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
               if xs.len() >= 3 {
                 let name = match &xs[1] {
                   Cirru::Leaf(s) => EdnTag::new(s.strip_prefix(':').unwrap_or(s)),
-                  Cirru::List(e) => {
+                  Cirru::List(_) => {
                     let mut name_path = path.clone();
                     name_path.push(1);
-                    return Err(EdnError::structure(
-                      format!("expected record name in string: {e:?}"),
+                    return Err(EdnError::structure_focused(
+                      "expected record name in string, got a list".to_string(),
                       name_path,
+                      &[1],
                       Some(node),
                     ));
                   }
@@ -447,9 +445,10 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                   child_path.push(i);
                   match x {
                     Cirru::Leaf(s) => {
-                      return Err(EdnError::structure(
+                      return Err(EdnError::structure_focused(
                         format!("expected record, invalid record entry: {s}"),
                         child_path,
+                        &[i],
                         Some(node),
                       ));
                     }
@@ -462,26 +461,24 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                             entries.push((EdnTag::new(s.strip_prefix(':').unwrap_or(s)), v));
                           }
                           (Cirru::Leaf(s), Err(e)) => {
-                            return Err(EdnError::structure(
-                              format!("invalid record value for `{s}`, got: {e}"),
-                              v_path,
-                              Some(node),
-                            ));
+                            return Err(EdnError::wrap_structure(format!("invalid record value for `{s}`"), v_path, &e));
                           }
-                          (Cirru::List(zs), _) => {
+                          (Cirru::List(_), _) => {
                             let mut k_path = child_path.clone();
                             k_path.push(0);
-                            return Err(EdnError::structure(
-                              format!("invalid list as record key: {zs:?}"),
+                            return Err(EdnError::structure_focused(
+                              "invalid list as record key, expected a tag or string".to_string(),
                               k_path,
+                              &[i, 0],
                               Some(node),
                             ));
                           }
                         }
                       } else {
-                        return Err(EdnError::structure(
-                          format!("expected pair of 2: {ys:?}"),
+                        return Err(EdnError::structure_focused(
+                          "expected pair of 2".to_string(),
                           child_path,
+                          &[i],
                           Some(node),
                         ));
                       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                         }
                         (Err(e), _) => {
                           return Err(EdnError::structure(
-                            format!("invalid map entry `{}` from `{}`", e, &ys[0]),
+                            format!("invalid map entry `{}` from `{}`", e, ys[0]),
                             k_path,
                             Some(node),
                           ));


### PR DESCRIPTION
Release 0.7.8 with the existing 0.7.7 release branch updates plus improved EDN error formatting.

Changes:
- Format nested error paths as `@1.2.3.4`.
- Avoid dumping full nested data in structure/value errors.
- Update README error examples and changelog.
- Bump crate version to `0.7.8`.

Validation:
- `cargo fmt --all`
- `git diff --check`
- `cargo test --offline --quiet` could not complete locally because Cargo hit a permission error unpacking the cached `alloca v0.4.0` crate under `~/.cargo/registry/src`.