### PR TITLE
release: 0.7.8 to release-0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.21] - Previous versions
 
 See git history for changes in previous versions.
+
+## [0.7.8] - 2026-07-21
+
+### Changed
+
+- Format nested structure/value error paths as `@1.2.3.4`.
+- Correct error handling documentation to match the public `EdnError` API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirru_edn"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -275,20 +275,14 @@ atom 1
 
 ### Error Handling (v0.7.0+)
 
-With cirru_parser 0.2.0, Cirru EDN provides enhanced error reporting with position information:
+With cirru_parser 0.2.0, Cirru EDN provides enhanced syntax-error reporting with source position information:
 
 ```rust
 use cirru_edn::{parse, EdnError};
 
 match parse("[] 1 2 invalid") {
     Ok(data) => println!("Parsed: {:?}", data),
-    Err(EdnError::ValueError { message, position }) => {
-        println!("Error: {}", message);
-        if let Some(pos) = position {
-            println!("  at line {}, column {}, byte {}",
-                     pos.line, pos.column, pos.offset);
-        }
-    }
+    Err(EdnError::ParseError { original }) => println!("Error: {}", original),
     Err(e) => println!("Other error: {}", e),
 }
 ```
@@ -299,6 +293,10 @@ Error types include:
 - `StructureError` - Invalid EDN structure
 - `ValueError` - Invalid values (e.g., bad hex, invalid tokens)
 - `DeserializationError` - Serde deserialization errors
+
+Structure and value errors include a nested Cirru path in `@1.2.3` notation; for example,
+`@1.2.3.4` means indices 1, 2, 3, and 4 from the root node. Syntax errors include
+line/column and byte-offset information when provided by the parser.
 
 See [ERROR_HANDLING.md](ERROR_HANDLING.md) for detailed documentation and examples.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,18 @@ impl fmt::Display for Position {
   }
 }
 
+/// Format a nested Cirru path using the conventional `@1.2.3` notation.
+fn format_path(path: &[usize]) -> String {
+  let mut result = String::from("@");
+  for (index, item) in path.iter().enumerate() {
+    if index > 0 {
+      result.push('.');
+    }
+    result.push_str(&item.to_string());
+  }
+  result
+}
+
 /// Errors that can occur during EDN parsing and manipulation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EdnError {
@@ -155,7 +167,7 @@ impl fmt::Display for EdnError {
       } => {
         write!(f, "Structure error")?;
         if !path.is_empty() {
-          write!(f, " at {path:?}")?;
+          write!(f, " at {}", format_path(path))?;
         }
         write!(f, ": {message}")?;
         if let Some(preview) = node_preview {
@@ -170,7 +182,7 @@ impl fmt::Display for EdnError {
       } => {
         write!(f, "Value error")?;
         if !path.is_empty() {
-          write!(f, " at {path:?}")?;
+          write!(f, " at {}", format_path(path))?;
         }
         write!(f, ": {message}")?;
         if let Some(preview) = node_preview {
@@ -190,6 +202,16 @@ impl From<&str> for EdnError {
     EdnError::ParseError {
       original: message.to_string(),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::format_path;
+
+  #[test]
+  fn formats_paths_with_at_and_dot_separators() {
+    assert_eq!(format_path(&[1, 2, 3, 4]), "@1.2.3.4");
   }
 }
 


### PR DESCRIPTION
## Summary\n- format structure/value error paths as @1.2.3.4\n- update error handling documentation\n- bump crate version to 0.7.8\n\n## Validation\n- cargo fmt --all\n- git diff --check\n- cargo test --offline --quiet (blocked by local Cargo cache permissions for alloca v0.4.0)