### PR TITLE
refactor: rename EDN records and tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,17 @@ match from_edn::<Person>(incomplete_edn) {
 
 See `examples/serde_demo.rs` for more complex nested structures and usage patterns.
 
-#### Record Deserialization
+#### Struct Deserialization
 
-Cirru EDN supports Record types with named tags, which can be deserialized to Rust structs. During deserialization, the record name is ignored since Rust structs don't expose their type names at runtime:
+Cirru EDN supports Struct values with symbol names, which can be deserialized to Rust structs. During deserialization, the struct name is ignored since Rust structs don't expose their type names at runtime:
 
 ```rust
-use cirru_edn::{Edn, EdnRecordView, EdnTag, from_edn};
+use cirru_edn::{Edn, EdnStructView, EdnTag, from_edn};
+use std::sync::Arc;
 
-// Create a Record with a named type
-let person_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("PersonRecord"),  // This name will be ignored during deserialization
+// Create a Struct with a symbol name
+let person_struct = Edn::Struct(EdnStructView {
+    name: Arc::from("Person"),  // This name will be ignored during deserialization
     pairs: vec![
         (EdnTag::new("name"), "Frank".into()),
         (EdnTag::new("age"), Edn::Number(42.0)),
@@ -139,23 +140,23 @@ let person_record = Edn::Record(EdnRecordView {
     ],
 });
 
-// Deserialize Record to struct (ignoring the record name)
-let person: Person = from_edn(person_record).unwrap();
+// Deserialize Struct to Rust struct (ignoring the struct name)
+let person: Person = from_edn(person_struct).unwrap();
 println!("{:?}", person);
 
-// Note: When serializing structs back to EDN, they become Maps, not Records
+// Note: When serializing structs back to EDN, they become Maps, not EDN Struct values
 // since Rust doesn't provide struct names at runtime
 let edn_back = to_edn(&person).unwrap();
-// This will be a Map, not a Record
+// This will be a Map, not an EDN Struct
 ```
 
-This feature allows interoperability between EDN data containing Records and Rust structs, with the semantic understanding that record names are metadata that may be lost during round-trip conversion.
+This feature allows interoperability between EDN data containing Struct values and Rust structs, with the semantic understanding that struct names are metadata that may be lost during round-trip conversion.
 
 #### Limitations
 
 - Some special Edn types (like `Quote`, `AnyRef`) cannot be serialized
 - Maps with complex keys will use their string representation when serializing structs
-- Record names are ignored during deserialization and structs serialize to Maps, not Records
+- Struct names are ignored during deserialization and Rust structs serialize to Maps, not EDN Struct values
 
 ### EDN Format
 
@@ -233,30 +234,30 @@ nested list:
 #{} ([] 3) 1
 ```
 
-tuple, or tagged union, actually very limitted due to Calcit semantics:
+enum, or tagged union, is limited by Calcit semantics:
 
 ```cirru
-:: :a
+:: 'a
 
-:: :b 1
+:: 'b 1
 ```
 
-extra values can be added to tuple since `0.3`:
+extra values can be added to an enum:
 
 ```cirru
-:: :a 1 |extra :l
+:: 'a 1 |extra :l
 ```
 
-newly added `%::` for representing enums with a type tag:
+`%::` represents enums with a symbol type name:
 
 ```cirru
-%:: :e :a 1 |extra :l
+%:: 'e 'a 1 |extra :l
 ```
 
-a record, notice that now it's all using tags:
+an EDN struct uses a symbol name and tag field keys:
 
 ```cirru
-%{} :Demo (:a 1)
+%{} 'Demo (:a 1)
   :b 2
   :c $ [] 1 2 3
 ```

--- a/examples/serde_demo.rs
+++ b/examples/serde_demo.rs
@@ -7,10 +7,11 @@
 #![allow(clippy::mutable_key_type)]
 #![allow(clippy::uninlined_format_args)]
 
-use cirru_edn::{Edn, EdnRecordView, EdnTag, from_edn, to_edn};
+use cirru_edn::{Edn, EdnStructView, EdnTag, from_edn, to_edn};
 use cirru_parser::Cirru;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct Person {
@@ -239,8 +240,8 @@ fn demo_record_deserialization() -> Result<(), String> {
   println!("8. Cirru EDN Record deserialization demo...");
 
   // Create a record manually - this represents what might come from EDN text parsing
-  let person_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("PersonRecord"), // This name will be ignored during deserialization
+  let person_record = Edn::Struct(EdnStructView {
+    name: Arc::from("PersonRecord"), // This name will be ignored during deserialization
     pairs: vec![
       (EdnTag::new("name"), "Frank".into()),
       (EdnTag::new("age"), Edn::Number(42.0)),
@@ -273,8 +274,8 @@ fn demo_record_deserialization() -> Result<(), String> {
   println!("{}\n", frank_edn);
 
   // Also demonstrate special fields with records
-  let special_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("SpecialPersonRecord"),
+  let special_record = Edn::Struct(EdnStructView {
+    name: Arc::from("SpecialPersonRecord"),
     pairs: vec![
       (EdnTag::new("name"), "Grace".into()),
       (EdnTag::new("age"), Edn::Number(29.0)),

--- a/src/edn.rs
+++ b/src/edn.rs
@@ -21,11 +21,11 @@ use std::{
 
 use cirru_parser::Cirru;
 
-pub use self::tuple::EdnTupleView;
+pub use self::tuple::EdnEnumView;
 pub use any_ref::{DynEq, EdnAnyRef};
 pub use list::EdnListView;
 pub use map::EdnMapView;
-pub use record::EdnRecordView;
+pub use record::EdnStructView;
 pub use set::EdnSetView;
 
 use crate::tag::EdnTag;
@@ -40,8 +40,8 @@ use crate::tag::EdnTag;
 ///
 /// - **Primitives**: `Nil`, `Bool`, `Number`, `Str`
 /// - **Named values**: `Symbol`, `Tag` (similar to keywords in other EDN implementations)
-/// - **Collections**: `List`, `Set`, `Map`, `Record`
-/// - **Special constructs**: `Quote`, `Tuple`, `Buffer`, `Atom`
+/// - **Collections**: `List`, `Set`, `Map`, `Struct`
+/// - **Special constructs**: `Quote`, `Enum`, `Buffer`, `Atom`
 /// - **Runtime references**: `AnyRef` (for holding arbitrary Rust data)
 ///
 /// # Examples
@@ -72,9 +72,9 @@ use crate::tag::EdnTag;
 ///     (Edn::tag("age"), Edn::Number(30.0)),
 /// ]);
 ///
-/// // Create a tuple (tagged union)
-/// let tuple_val = Edn::tuple(
-///     Edn::tag("user"),
+/// // Create an enum value
+/// let enum_value = Edn::enum_value(
+///     "user",
 ///     vec![Edn::str("john"), Edn::Number(25.0)]
 /// );
 /// ```
@@ -97,18 +97,18 @@ pub enum Edn {
   Str(Arc<str>), // name collision
   /// Quoted Cirru code that is not evaluated. Used to represent code as data.
   Quote(Cirru),
-  /// Tuple - a tagged union type with a tag and optional extra values.
+  /// Enum - a tagged union type with a variant and optional extra values.
   /// Useful for discriminated unions and algebraic data types.
-  Tuple(EdnTupleView),
+  Enum(EdnEnumView),
   /// Ordered sequence of values. Rendered as `([] item1 item2 ...)`.
   List(EdnListView),
   /// Unordered collection of unique values. Rendered as `(#{} item1 item2 ...)`.
   Set(EdnSetView),
   /// Key-value mapping. Rendered as `({} (key1 value1) (key2 value2) ...)`.
   Map(EdnMapView),
-  /// Record - a structured data type with a type name and named fields.
+  /// Struct - a structured data type with a type name and named fields.
   /// Similar to structs in other languages.
-  Record(EdnRecordView),
+  Struct(EdnStructView),
   /// Binary data buffer. Rendered as `(buf 01 ff a2 ...)` with hex values.
   Buffer(Vec<u8>),
   /// Reference to arbitrary Rust data that cannot be serialized to EDN.
@@ -143,17 +143,21 @@ impl fmt::Display for Edn {
         }
       }
       Self::Quote(v) => f.write_fmt(format_args!("(quote {v})")),
-      Self::Tuple(EdnTupleView { tag, enum_tag, extra }) => {
+      Self::Enum(EdnEnumView {
+        variant,
+        type_name,
+        extra,
+      }) => {
         let mut extra_str = String::new();
         for item in extra {
           extra_str.push(' ');
           extra_str.push_str(&item.to_string());
         }
 
-        if let Some(et) = enum_tag {
-          f.write_fmt(format_args!("(%:: {et} {tag}{extra_str})"))
+        if let Some(et) = type_name {
+          f.write_fmt(format_args!("(%:: '{et} '{variant}{extra_str})"))
         } else {
-          f.write_fmt(format_args!("(:: {tag}{extra_str})"))
+          f.write_fmt(format_args!("(:: '{variant}{extra_str})"))
         }
       }
       Self::List(EdnListView(xs)) => {
@@ -177,11 +181,8 @@ impl fmt::Display for Edn {
         }
         f.write_str(")")
       }
-      Self::Record(EdnRecordView {
-        tag: name,
-        pairs: entries,
-      }) => {
-        f.write_fmt(format_args!("(%{{}} :{name}"))?;
+      Self::Struct(EdnStructView { name, pairs: entries }) => {
+        f.write_fmt(format_args!("(%{{}} '{name}"))?;
 
         for entry in entries {
           f.write_fmt(format_args!(" ({} {})", Edn::Tag(entry.0.to_owned()), entry.1))?;
@@ -248,14 +249,14 @@ impl Hash for Edn {
         "quote:".hash(_state);
         v.hash(_state);
       }
-      Self::Tuple(EdnTupleView {
-        tag: pair,
-        enum_tag,
+      Self::Enum(EdnEnumView {
+        variant: pair,
+        type_name,
         extra,
       }) => {
         "tuple".hash(_state);
         pair.hash(_state);
-        enum_tag.hash(_state);
+        type_name.hash(_state);
         extra.hash(_state);
       }
       Self::List(v) => {
@@ -276,10 +277,7 @@ impl Hash for Edn {
           x.hash(_state)
         }
       }
-      Self::Record(EdnRecordView {
-        tag: name,
-        pairs: entries,
-      }) => {
+      Self::Struct(EdnStructView { name, pairs: entries }) => {
         "record:".hash(_state);
         name.hash(_state);
         entries.hash(_state);
@@ -341,9 +339,9 @@ impl Ord for Edn {
       (Self::Quote(_), _) => Less,
       (_, Self::Quote(_)) => Greater,
 
-      (Self::Tuple(a), Self::Tuple(b)) => a.cmp(b),
-      (Self::Tuple(..), _) => Less,
-      (_, Self::Tuple(..)) => Greater,
+      (Self::Enum(a), Self::Enum(b)) => a.cmp(b),
+      (Self::Enum(..), _) => Less,
+      (_, Self::Enum(..)) => Greater,
 
       (Self::List(a), Self::List(b)) => a.cmp(b),
       (Self::List(_), _) => Less,
@@ -370,18 +368,18 @@ impl Ord for Edn {
       (_, Self::Map(_)) => Greater,
 
       (
-        Self::Record(EdnRecordView {
-          tag: name1,
+        Self::Struct(EdnStructView {
+          name: name1,
           pairs: entries1,
         }),
-        Self::Record(EdnRecordView {
-          tag: name2,
+        Self::Struct(EdnStructView {
+          name: name2,
           pairs: entries2,
         }),
       ) => name1.cmp(name2).then_with(|| entries1.cmp(entries2)),
 
-      (Self::Record(..), _) => Less,
-      (_, Self::Record(..)) => Greater,
+      (Self::Struct(..), _) => Less,
+      (_, Self::Struct(..)) => Greater,
 
       (Self::Atom(a), Self::Atom(b)) => a.cmp(b),
       (Self::Atom(_), _) => Less,
@@ -416,12 +414,12 @@ impl PartialEq for Edn {
       (Self::Tag(a), Self::Tag(b)) => a == b,
       (Self::Str(a), Self::Str(b)) => a == b,
       (Self::Quote(a), Self::Quote(b)) => a == b,
-      (Self::Tuple(a), Self::Tuple(b)) => a == b,
+      (Self::Enum(a), Self::Enum(b)) => a == b,
       (Self::List(a), Self::List(b)) => a == b,
       (Self::Buffer(a), Self::Buffer(b)) => a == b,
       (Self::Set(a), Self::Set(b)) => a == b,
       (Self::Map(a), Self::Map(b)) => a == b,
-      (Self::Record(a), Self::Record(b)) => a == b,
+      (Self::Struct(a), Self::Struct(b)) => a == b,
       (Self::AnyRef(a), Self::AnyRef(b)) => a == b,
       (Self::Atom(a), Self::Atom(b)) => a == b,
       (_, _) => false,
@@ -443,19 +441,19 @@ impl Edn {
   pub fn sym<T: Into<Arc<str>>>(s: T) -> Self {
     Edn::Symbol(s.into())
   }
-  /// create new tuple
-  pub fn tuple(tag: Self, extra: Vec<Self>) -> Self {
-    Edn::Tuple(EdnTupleView {
-      tag: Arc::new(tag),
-      enum_tag: None,
+  /// Create an enum value without a nominal enum type.
+  pub fn enum_value(variant: impl Into<Arc<str>>, extra: Vec<Self>) -> Self {
+    Edn::Enum(EdnEnumView {
+      variant: variant.into(),
+      type_name: None,
       extra,
     })
   }
-  /// create new enum tuple
-  pub fn enum_tuple(enum_tag: Self, tag: Self, extra: Vec<Self>) -> Self {
-    Edn::Tuple(EdnTupleView {
-      tag: Arc::new(tag),
-      enum_tag: Some(Arc::new(enum_tag)),
+  /// Create a nominal enum value from a type and variant symbol.
+  pub fn typed_enum(type_name: impl Into<Arc<str>>, variant: impl Into<Arc<str>>, extra: Vec<Self>) -> Self {
+    Edn::Enum(EdnEnumView {
+      variant: variant.into(),
+      type_name: Some(type_name.into()),
       extra,
     })
   }
@@ -475,10 +473,10 @@ impl Edn {
     Self::Map(EdnMapView(HashMap::from_iter(pairs)))
   }
 
-  /// Create a record from a tag and field pairs
-  pub fn record_from_pairs(tag: EdnTag, pairs: &[(EdnTag, Edn)]) -> Self {
-    Self::Record(EdnRecordView {
-      tag,
+  /// Create a struct from a symbol name and field pairs.
+  pub fn struct_from_pairs(name: impl Into<Arc<str>>, pairs: &[(EdnTag, Edn)]) -> Self {
+    Self::Struct(EdnStructView {
+      name: name.into(),
       pairs: pairs.to_vec(),
     })
   }
@@ -576,26 +574,30 @@ impl Edn {
     }
   }
 
-  /// get Record variant in struct
-  pub fn view_record(&self) -> Result<EdnRecordView, String> {
+  /// Get the struct view.
+  pub fn view_struct(&self) -> Result<EdnStructView, String> {
     match self {
-      Edn::Record(EdnRecordView { tag, pairs }) => Ok(EdnRecordView {
-        tag: tag.to_owned(),
+      Edn::Struct(EdnStructView { name, pairs }) => Ok(EdnStructView {
+        name: name.to_owned(),
         pairs: pairs.to_owned(),
       }),
-      a => Err(format!("failed to convert to record: {a}")),
+      value => Err(format!("failed to convert to struct: {value}")),
     }
   }
 
-  /// get Tuple variant in struct
-  pub fn view_tuple(&self) -> Result<EdnTupleView, String> {
+  /// Get the enum view.
+  pub fn view_enum(&self) -> Result<EdnEnumView, String> {
     match self {
-      Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => Ok(EdnTupleView {
-        tag: tag.to_owned(),
-        enum_tag: enum_tag.to_owned(),
+      Edn::Enum(EdnEnumView {
+        variant,
+        type_name,
+        extra,
+      }) => Ok(EdnEnumView {
+        variant: variant.to_owned(),
+        type_name: type_name.to_owned(),
         extra: extra.to_owned(),
       }),
-      a => Err(format!("failed to convert to tuple: {a}")),
+      value => Err(format!("failed to convert to enum: {value}")),
     }
   }
 
@@ -646,14 +648,14 @@ impl Edn {
     matches!(self, Edn::Map(_))
   }
 
-  /// Check if the value is a record
-  pub fn is_record(&self) -> bool {
-    matches!(self, Edn::Record(_))
+  /// Check if the value is a struct.
+  pub fn is_struct(&self) -> bool {
+    matches!(self, Edn::Struct(_))
   }
 
-  /// Check if the value is a tuple
-  pub fn is_tuple(&self) -> bool {
-    matches!(self, Edn::Tuple(_))
+  /// Check if the value is an enum.
+  pub fn is_enum(&self) -> bool {
+    matches!(self, Edn::Enum(_))
   }
 
   /// Check if the value is a buffer
@@ -681,11 +683,11 @@ impl Edn {
       Edn::Tag(_) => "tag",
       Edn::Str(_) => "string",
       Edn::Quote(_) => "quote",
-      Edn::Tuple(_) => "tuple",
+      Edn::Enum(_) => "enum",
       Edn::List(_) => "list",
       Edn::Set(_) => "set",
       Edn::Map(_) => "map",
-      Edn::Record(_) => "record",
+      Edn::Struct(_) => "struct",
       Edn::Buffer(_) => "buffer",
       Edn::AnyRef(_) => "any-ref",
       Edn::Atom(_) => "atom",
@@ -723,10 +725,10 @@ impl Edn {
     }
   }
 
-  /// Try to access record field by tag (returns None for non-records or missing fields)
-  pub fn get_record_field(&self, field: &EdnTag) -> Option<&Edn> {
+  /// Try to access a struct field by tag (returns None for non-structs or missing fields).
+  pub fn get_struct_field(&self, field: &EdnTag) -> Option<&Edn> {
     match self {
-      Edn::Record(record) => {
+      Edn::Struct(record) => {
         for (tag, value) in &record.pairs {
           if tag == field {
             return Some(value);
@@ -1192,21 +1194,21 @@ where
   }
 }
 
-impl From<(Arc<Edn>, Vec<Edn>)> for Edn {
-  fn from((tag, extra): (Arc<Edn>, Vec<Edn>)) -> Edn {
-    Edn::Tuple(EdnTupleView {
-      tag,
-      enum_tag: None,
+impl From<(Arc<str>, Vec<Edn>)> for Edn {
+  fn from((variant, extra): (Arc<str>, Vec<Edn>)) -> Edn {
+    Edn::Enum(EdnEnumView {
+      variant,
+      type_name: None,
       extra,
     })
   }
 }
 
-impl From<(Arc<Edn>, Arc<Edn>, Vec<Edn>)> for Edn {
-  fn from((enum_tag, tag, extra): (Arc<Edn>, Arc<Edn>, Vec<Edn>)) -> Edn {
-    Edn::Tuple(EdnTupleView {
-      tag,
-      enum_tag: Some(enum_tag),
+impl From<(Arc<str>, Arc<str>, Vec<Edn>)> for Edn {
+  fn from((type_name, variant, extra): (Arc<str>, Arc<str>, Vec<Edn>)) -> Edn {
+    Edn::Enum(EdnEnumView {
+      variant,
+      type_name: Some(type_name),
       extra,
     })
   }

--- a/src/edn/record.rs
+++ b/src/edn/record.rs
@@ -1,45 +1,45 @@
-// Record
+// Struct
 
-/// Record interface for Edn::Record
+/// Struct interface for Edn::Struct.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EdnRecordView {
-  pub tag: EdnTag,
+pub struct EdnStructView {
+  pub name: Arc<str>,
   pub pairs: Vec<(EdnTag, Edn)>,
 }
 
-impl PartialOrd for EdnRecordView {
+impl PartialOrd for EdnStructView {
   fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
     Some(std::cmp::Ord::cmp(self, other))
   }
 }
 
-impl Ord for EdnRecordView {
+impl Ord for EdnStructView {
   fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-    self.tag.cmp(&other.tag).then_with(|| self.pairs.cmp(&other.pairs))
+    self.name.cmp(&other.name).then_with(|| self.pairs.cmp(&other.pairs))
   }
 }
 
-impl TryFrom<Edn> for EdnRecordView {
+impl TryFrom<Edn> for EdnStructView {
   type Error = String;
 
   fn try_from(data: Edn) -> Result<Self, Self::Error> {
     match data {
-      Edn::Record(EdnRecordView { tag: t, pairs }) => {
+      Edn::Struct(EdnStructView { name, pairs }) => {
         let mut buf = vec![];
         for pair in pairs {
           buf.push((pair.0, pair.1));
         }
-        Ok(EdnRecordView { tag: t, pairs: buf })
+        Ok(EdnStructView { name, pairs: buf })
       }
-      a => Err(format!("data is not record: {a}")),
+      value => Err(format!("data is not struct: {value}")),
     }
   }
 }
 
-impl From<EdnRecordView> for Edn {
-  fn from(x: EdnRecordView) -> Edn {
-    Edn::Record(EdnRecordView {
-      tag: x.tag,
+impl From<EdnStructView> for Edn {
+  fn from(x: EdnStructView) -> Edn {
+    Edn::Struct(EdnStructView {
+      name: x.name,
       pairs: x.pairs,
     })
   }
@@ -48,7 +48,8 @@ impl From<EdnRecordView> for Edn {
 use std::ops::Index;
 
 use crate::{Edn, EdnTag};
-impl Index<&str> for EdnRecordView {
+use std::sync::Arc;
+impl Index<&str> for EdnStructView {
   type Output = Edn;
 
   fn index(&self, index: &str) -> &Self::Output {
@@ -61,9 +62,12 @@ impl Index<&str> for EdnRecordView {
   }
 }
 
-impl EdnRecordView {
-  pub fn new(tag: EdnTag) -> EdnRecordView {
-    EdnRecordView { tag, pairs: vec![] }
+impl EdnStructView {
+  pub fn new(name: impl Into<Arc<str>>) -> EdnStructView {
+    EdnStructView {
+      name: name.into(),
+      pairs: vec![],
+    }
   }
 
   pub fn has_key(&self, key: &str) -> bool {
@@ -75,7 +79,7 @@ impl EdnRecordView {
     false
   }
 
-  /// quick hand for building record
+  /// Quick helper for building a struct.
   pub fn insert(&mut self, k: impl Into<EdnTag>, v: Edn) {
     self.pairs.push((k.into(), v))
   }

--- a/src/edn/tuple.rs
+++ b/src/edn/tuple.rs
@@ -3,66 +3,74 @@ use std::sync::Arc;
 use crate::Edn;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EdnTupleView {
-  pub tag: Arc<Edn>,
-  pub enum_tag: Option<Arc<Edn>>,
+pub struct EdnEnumView {
+  pub variant: Arc<str>,
+  pub type_name: Option<Arc<str>>,
   pub extra: Vec<Edn>,
 }
 
-impl From<(Arc<Edn>, Vec<Edn>)> for EdnTupleView {
-  fn from((tag, extra): (Arc<Edn>, Vec<Edn>)) -> EdnTupleView {
-    EdnTupleView {
-      tag,
-      enum_tag: None,
+impl From<(Arc<str>, Vec<Edn>)> for EdnEnumView {
+  fn from((variant, extra): (Arc<str>, Vec<Edn>)) -> EdnEnumView {
+    EdnEnumView {
+      variant,
+      type_name: None,
       extra,
     }
   }
 }
 
-impl From<(Arc<Edn>, Arc<Edn>, Vec<Edn>)> for EdnTupleView {
-  fn from((enum_tag, tag, extra): (Arc<Edn>, Arc<Edn>, Vec<Edn>)) -> EdnTupleView {
-    EdnTupleView {
-      tag,
-      enum_tag: Some(enum_tag),
+impl From<(Arc<str>, Arc<str>, Vec<Edn>)> for EdnEnumView {
+  fn from((type_name, variant, extra): (Arc<str>, Arc<str>, Vec<Edn>)) -> EdnEnumView {
+    EdnEnumView {
+      variant,
+      type_name: Some(type_name),
       extra,
     }
   }
 }
 
-impl From<EdnTupleView> for (Arc<Edn>, Vec<Edn>) {
-  fn from(x: EdnTupleView) -> (Arc<Edn>, Vec<Edn>) {
-    (x.tag, x.extra)
+impl From<EdnEnumView> for (Arc<str>, Vec<Edn>) {
+  fn from(x: EdnEnumView) -> (Arc<str>, Vec<Edn>) {
+    (x.variant, x.extra)
   }
 }
 
-impl TryFrom<Edn> for EdnTupleView {
+impl TryFrom<Edn> for EdnEnumView {
   type Error = String;
 
   fn try_from(data: Edn) -> Result<Self, Self::Error> {
     match data {
-      Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => Ok(EdnTupleView { tag, enum_tag, extra }),
-      a => Err(format!("data is not tuple: {a}")),
+      Edn::Enum(EdnEnumView {
+        variant,
+        type_name,
+        extra,
+      }) => Ok(EdnEnumView {
+        variant,
+        type_name,
+        extra,
+      }),
+      value => Err(format!("data is not enum: {value}")),
     }
   }
 }
 
-impl From<EdnTupleView> for Edn {
-  fn from(x: EdnTupleView) -> Edn {
-    Edn::Tuple(x)
+impl From<EdnEnumView> for Edn {
+  fn from(x: EdnEnumView) -> Edn {
+    Edn::Enum(x)
   }
 }
 
-impl Ord for EdnTupleView {
+impl Ord for EdnEnumView {
   fn cmp(&self, other: &Self) -> std::cmp::Ordering {
     self
-      .enum_tag
-      .cmp(&other.enum_tag)
-      .then_with(|| self.tag.cmp(&other.tag))
+      .type_name
+      .cmp(&other.type_name)
+      .then_with(|| self.variant.cmp(&other.variant))
       .then_with(|| self.extra.cmp(&other.extra))
   }
 }
 
-impl PartialOrd for EdnTupleView {
+impl PartialOrd for EdnEnumView {
   fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
     Some(self.cmp(other))
   }

--- a/src/error.rs
+++ b/src/error.rs
@@ -111,52 +111,58 @@ impl EdnError {
     }
   }
 
-/// Create a structure error with path and node preview, using `focus_path`
-/// for structural folding (relative to `node`) while `path` is used for display.
-pub fn structure_focused(
-  message: impl Into<String>,
-  path: Vec<usize>,
-  focus_path: &[usize],
-  node: Option<&Cirru>,
-) -> Self {
-  let node_preview = node.and_then(|n| {
-    let folded = cirru_parser::focus_cirru_preview(n, focus_path);
-    cirru_parser::format(std::slice::from_ref(&folded), false.into()).ok().map(|s| s.trim().to_string())
-  });
-  EdnError::StructureError {
-    message: message.into(),
-    path,
-    node_preview,
+  /// Create a structure error with path and node preview, using `focus_path`
+  /// for structural folding (relative to `node`) while `path` is used for display.
+  pub fn structure_focused(
+    message: impl Into<String>,
+    path: Vec<usize>,
+    focus_path: &[usize],
+    node: Option<&Cirru>,
+  ) -> Self {
+    let node_preview = node.and_then(|n| {
+      let folded = cirru_parser::focus_cirru_preview(n, focus_path);
+      cirru_parser::format(std::slice::from_ref(&folded), false.into())
+        .ok()
+        .map(|s| s.trim().to_string())
+    });
+    EdnError::StructureError {
+      message: message.into(),
+      path,
+      node_preview,
+    }
   }
-}
 
-/// Create a structure error with path and node preview.
-/// The node is structurally folded along `path` before formatting.
-pub fn structure(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
-  let node_preview = node.and_then(|n| {
-    let folded = cirru_parser::focus_cirru_preview(n, &path);
-    cirru_parser::format(std::slice::from_ref(&folded), false.into()).ok().map(|s| s.trim().to_string())
-  });
-  EdnError::StructureError {
-    message: message.into(),
-    path,
-    node_preview,
+  /// Create a structure error with path and node preview.
+  /// The node is structurally folded along `path` before formatting.
+  pub fn structure(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
+    let node_preview = node.and_then(|n| {
+      let folded = cirru_parser::focus_cirru_preview(n, &path);
+      cirru_parser::format(std::slice::from_ref(&folded), false.into())
+        .ok()
+        .map(|s| s.trim().to_string())
+    });
+    EdnError::StructureError {
+      message: message.into(),
+      path,
+      node_preview,
+    }
   }
-}
 
-/// Create a value error with path and node preview.
-/// The node is structurally folded along `path` before formatting.
-pub fn value(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
-  let node_preview = node.and_then(|n| {
-    let folded = cirru_parser::focus_cirru_preview(n, &path);
-    cirru_parser::format(std::slice::from_ref(&folded), false.into()).ok().map(|s| s.trim().to_string())
-  });
-  EdnError::ValueError {
-    message: message.into(),
-    path,
-    node_preview,
+  /// Create a value error with path and node preview.
+  /// The node is structurally folded along `path` before formatting.
+  pub fn value(message: impl Into<String>, path: Vec<usize>, node: Option<&Cirru>) -> Self {
+    let node_preview = node.and_then(|n| {
+      let folded = cirru_parser::focus_cirru_preview(n, &path);
+      cirru_parser::format(std::slice::from_ref(&folded), false.into())
+        .ok()
+        .map(|s| s.trim().to_string())
+    });
+    EdnError::ValueError {
+      message: message.into(),
+      path,
+      node_preview,
+    }
   }
-}
 
   /// Create a deserialization error with position
   pub fn deserialization(message: impl Into<String>, position: Option<Vec<u8>>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,10 +499,7 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                 if entries.is_empty() {
                   return Err(EdnError::structure("empty record is invalid", path.clone(), Some(node)));
                 }
-                Ok(Edn::Struct(EdnStructView {
-                  name: name,
-                  pairs: entries,
-                }))
+                Ok(Edn::Struct(EdnStructView { name, pairs: entries }))
               } else {
                 Err(EdnError::structure(
                   "insufficient items for edn record",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@
 //!
 //! This crate provides a data format similar to EDN but using Cirru's syntax instead of
 //! traditional s-expressions. It supports rich data types including primitives, collections,
-//! and special constructs like records and tuples.
+//! and special constructs like structs and enums.
 //!
 //! ## Features
 //!
-//! - **Rich data types**: nil, boolean, number, string, symbol, tag, list, set, map, record, tuple, buffer, atom
+//! - **Rich data types**: nil, boolean, number, string, symbol, tag, list, set, map, struct, enum, buffer, atom
 //! - **Serde integration**: Seamless serialization/deserialization with Rust structs
 //! - **Efficient string handling**: Uses `Arc<str>` for string deduplication
 //! - **Runtime references**: Support for arbitrary Rust data via `AnyRef`
@@ -113,9 +113,7 @@ use std::vec;
 
 use cirru_parser::Cirru;
 
-pub use edn::{
-  DynEq, Edn, EdnAnyRef, EdnListView, EdnMapView, EdnRecordView, EdnSetView, EdnTupleView, is_simple_char,
-};
+pub use edn::{DynEq, Edn, EdnAnyRef, EdnEnumView, EdnListView, EdnMapView, EdnSetView, EdnStructView, is_simple_char};
 pub use error::{EdnError, EdnResult, Position};
 pub use tag::EdnTag;
 
@@ -132,8 +130,6 @@ pub type EdnResultString<T> = Result<T, String>;
 pub type EdnList = EdnListView;
 pub type EdnMap = EdnMapView;
 pub type EdnSet = EdnSetView;
-pub type EdnRecord = EdnRecordView;
-pub type EdnTuple = EdnTupleView;
 
 // Common constants for convenience
 impl Edn {
@@ -285,7 +281,7 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
               ret.ok_or_else(|| EdnError::structure("missing edn do value", path.clone(), Some(node)))
             }
             "::" => {
-              let mut tag: Option<Edn> = None;
+              let mut variant: Option<Arc<str>> = None;
               let mut extra: Vec<Edn> = vec![];
               for (i, x) in xs.iter().enumerate().skip(1) {
                 if is_comment(x) {
@@ -293,17 +289,17 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                 }
                 let mut child_path = path.clone();
                 child_path.push(i);
-                if tag.is_some() {
+                if variant.is_some() {
                   extra.push(extract_cirru_edn_with_path(x, child_path)?);
                   continue;
                 } else {
-                  tag = Some(extract_cirru_edn_with_path(x, child_path)?);
+                  variant = Some(extract_symbol_name(x, child_path)?);
                 }
               }
-              if let Some(x0) = tag {
-                Ok(Edn::Tuple(EdnTupleView {
-                  tag: Arc::new(x0),
-                  enum_tag: None,
+              if let Some(variant) = variant {
+                Ok(Edn::Enum(EdnEnumView {
+                  variant,
+                  type_name: None,
                   extra,
                 }))
               } else {
@@ -315,8 +311,8 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
               }
             }
             "%::" => {
-              let mut enum_tag: Option<Edn> = None;
-              let mut tag: Option<Edn> = None;
+              let mut type_name: Option<Arc<str>> = None;
+              let mut variant: Option<Arc<str>> = None;
               let mut extra: Vec<Edn> = vec![];
               for (i, x) in xs.iter().enumerate().skip(1) {
                 if is_comment(x) {
@@ -324,23 +320,23 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                 }
                 let mut child_path = path.clone();
                 child_path.push(i);
-                if enum_tag.is_none() {
-                  enum_tag = Some(extract_cirru_edn_with_path(x, child_path)?);
-                } else if tag.is_none() {
-                  tag = Some(extract_cirru_edn_with_path(x, child_path)?);
+                if type_name.is_none() {
+                  type_name = Some(extract_symbol_name(x, child_path)?);
+                } else if variant.is_none() {
+                  variant = Some(extract_symbol_name(x, child_path)?);
                 } else {
                   extra.push(extract_cirru_edn_with_path(x, child_path)?);
                 }
               }
-              if let (Some(e0), Some(x0)) = (enum_tag, tag) {
-                Ok(Edn::Tuple(EdnTupleView {
-                  tag: Arc::new(x0),
-                  enum_tag: Some(Arc::new(e0)),
+              if let (Some(type_name), Some(variant)) = (type_name, variant) {
+                Ok(Edn::Enum(EdnEnumView {
+                  variant,
+                  type_name: Some(type_name),
                   extra,
                 }))
               } else {
                 Err(EdnError::structure(
-                  "missing edn %:: enum_tag or tag value",
+                  "missing edn %:: type or variant symbol",
                   path.clone(),
                   Some(node),
                 ))
@@ -411,7 +407,11 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                           ));
                         }
                         (Ok(k), Err(e)) => {
-                          return Err(EdnError::wrap_structure(format!("invalid map entry for `{k}`"), v_path, &e));
+                          return Err(EdnError::wrap_structure(
+                            format!("invalid map entry for `{k}`"),
+                            v_path,
+                            &e,
+                          ));
                         }
                       }
                     }
@@ -423,12 +423,19 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
             "%{}" => {
               if xs.len() >= 3 {
                 let name = match &xs[1] {
-                  Cirru::Leaf(s) => EdnTag::new(s.strip_prefix(':').unwrap_or(s)),
+                  Cirru::Leaf(s) => symbol_name_from_leaf(s).map(Arc::from).ok_or_else(|| {
+                    EdnError::structure_focused(
+                      "expected struct name symbol".to_string(),
+                      path.clone(),
+                      &[1],
+                      Some(node),
+                    )
+                  })?,
                   Cirru::List(_) => {
                     let mut name_path = path.clone();
                     name_path.push(1);
                     return Err(EdnError::structure_focused(
-                      "expected record name in string, got a list".to_string(),
+                      "expected struct name symbol, got a list".to_string(),
                       name_path,
                       &[1],
                       Some(node),
@@ -461,7 +468,11 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                             entries.push((EdnTag::new(s.strip_prefix(':').unwrap_or(s)), v));
                           }
                           (Cirru::Leaf(s), Err(e)) => {
-                            return Err(EdnError::wrap_structure(format!("invalid record value for `{s}`"), v_path, &e));
+                            return Err(EdnError::wrap_structure(
+                              format!("invalid record value for `{s}`"),
+                              v_path,
+                              &e,
+                            ));
                           }
                           (Cirru::List(_), _) => {
                             let mut k_path = child_path.clone();
@@ -488,8 +499,8 @@ fn extract_cirru_edn_with_path(node: &Cirru, path: Vec<usize>) -> EdnResult<Edn>
                 if entries.is_empty() {
                   return Err(EdnError::structure("empty record is invalid", path.clone(), Some(node)));
                 }
-                Ok(Edn::Record(EdnRecordView {
-                  tag: name,
+                Ok(Edn::Struct(EdnStructView {
+                  name: name,
                   pairs: entries,
                 }))
               } else {
@@ -583,6 +594,22 @@ fn is_comment(node: &Cirru) -> bool {
   }
 }
 
+fn symbol_name_from_leaf(raw: &str) -> Option<&str> {
+  raw
+    .strip_prefix('\'')
+    .or_else(|| raw.strip_prefix(':'))
+    .filter(|name| !name.is_empty())
+}
+
+fn extract_symbol_name(node: &Cirru, path: Vec<usize>) -> EdnResult<Arc<str>> {
+  match node {
+    Cirru::Leaf(raw) => symbol_name_from_leaf(raw)
+      .map(Arc::from)
+      .ok_or_else(|| EdnError::structure("expected symbol name or legacy tag", path, Some(node))),
+    Cirru::List(_) => Err(EdnError::structure("expected symbol name, got list", path, Some(node))),
+  }
+}
+
 fn assemble_cirru_node(data: &Edn) -> Cirru {
   match data {
     Edn::Nil => "nil".into(),
@@ -628,13 +655,10 @@ fn assemble_cirru_node(data: &Edn) -> Cirru {
       }
       Cirru::List(ys)
     }
-    Edn::Record(EdnRecordView {
-      tag: name,
-      pairs: entries,
-    }) => {
+    Edn::Struct(EdnStructView { name, pairs: entries }) => {
       let mut ys: Vec<Cirru> = Vec::with_capacity(entries.len() + 2);
       ys.push("%{}".into());
-      ys.push(format!(":{name}").as_str().into());
+      ys.push(format!("'{name}").as_str().into());
       let mut ordered_entries = entries.to_owned();
       ordered_entries.sort_by(|(a1, a2), (b1, b2)| match (a2.is_literal(), b2.is_literal()) {
         (true, false) => Less,
@@ -651,11 +675,19 @@ fn assemble_cirru_node(data: &Edn) -> Cirru {
 
       Cirru::List(ys)
     }
-    Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => {
-      let mut ys: Vec<Cirru> = if let Some(et) = enum_tag {
-        vec!["%::".into(), assemble_cirru_node(et), assemble_cirru_node(tag)]
+    Edn::Enum(EdnEnumView {
+      variant,
+      type_name,
+      extra,
+    }) => {
+      let mut ys: Vec<Cirru> = if let Some(et) = type_name {
+        vec![
+          "%::".into(),
+          format!("'{et}").as_str().into(),
+          format!("'{variant}").as_str().into(),
+        ]
       } else {
-        vec!["::".into(), assemble_cirru_node(tag)]
+        vec!["::".into(), format!("'{variant}").as_str().into()]
       };
       for item in extra {
         ys.push(assemble_cirru_node(item))

--- a/src/serde_support.rs
+++ b/src/serde_support.rs
@@ -60,7 +60,7 @@
 //! - `Tag` -> `{"__edn_tag": "value"}`
 //! - `Set` -> `{"__edn_set": [items]}`
 //! - `Buffer` -> `{"__edn_buffer": [bytes]}`
-//! - `Tuple` -> `{"__edn_tuple_tag": tag, "__edn_tuple_extra": [values], "__edn_tuple_enum": enum_tag}` (enum_tag is optional)
+//! - `Tuple` -> `{"__edn_tuple_tag": tag, "__edn_tuple_extra": [values], "__edn_tuple_enum": type_name}` (type_name is optional)
 
 #![allow(clippy::mutable_key_type)]
 #![allow(clippy::uninlined_format_args)]
@@ -77,8 +77,16 @@ use serde::{
   },
 };
 
-use crate::{Edn, EdnListView, EdnMapView, EdnRecordView, EdnSetView, EdnTag, EdnTupleView};
+use crate::{Edn, EdnEnumView, EdnListView, EdnMapView, EdnSetView, EdnStructView, EdnTag};
 use cirru_parser::Cirru;
+
+fn edn_symbol_name(value: &Edn) -> Option<Arc<str>> {
+  match value {
+    Edn::Symbol(name) | Edn::Str(name) => Some(name.clone()),
+    Edn::Tag(tag) => Some(tag.arc_str()),
+    _ => None,
+  }
+}
 
 impl Serialize for Edn {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -105,14 +113,18 @@ impl Serialize for Edn {
         map.serialize_entry("__edn_quote", cirru)?;
         map.end()
       }
-      Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => {
-        let n = if enum_tag.is_some() { 3 } else { 2 };
+      Edn::Enum(EdnEnumView {
+        variant,
+        type_name,
+        extra,
+      }) => {
+        let n = if type_name.is_some() { 3 } else { 2 };
         let mut map = serializer.serialize_map(Some(n))?;
-        if let Some(et) = enum_tag {
-          map.serialize_entry("__edn_tuple_enum", et.as_ref())?;
+        if let Some(et) = type_name {
+          map.serialize_entry("__edn_enum_type", et.as_ref())?;
         }
-        map.serialize_entry("__edn_tuple_tag", tag.as_ref())?;
-        map.serialize_entry("__edn_tuple_extra", extra)?;
+        map.serialize_entry("__edn_enum_variant", variant.as_ref())?;
+        map.serialize_entry("__edn_enum_extra", extra)?;
         map.end()
       }
       Edn::List(EdnListView(list)) => {
@@ -142,9 +154,9 @@ impl Serialize for Edn {
         }
         ser_map.end()
       }
-      Edn::Record(EdnRecordView { tag, pairs }) => {
+      Edn::Struct(EdnStructView { name, pairs }) => {
         let mut map = serializer.serialize_map(Some(pairs.len() + 1))?;
-        map.serialize_entry("__edn_record_tag", &tag.to_string())?;
+        map.serialize_entry("__edn_struct_name", name.as_ref())?;
         for (key, value) in pairs {
           map.serialize_entry(&key.to_string(), value)?;
         }
@@ -277,16 +289,27 @@ impl<'de> Deserialize<'de> for Edn {
                   Err(de::Error::custom("Invalid tag data"))
                 }
               }
-              "__edn_tuple_tag" | "__edn_tuple_enum" | "__edn_tuple_extra" => {
-                if let (Some(tag), Some(extra)) = (
-                  special_data.get("__edn_tuple_tag"),
-                  special_data.get("__edn_tuple_extra"),
+              "__edn_enum_variant" | "__edn_enum_type" | "__edn_enum_extra" | "__edn_tuple_tag"
+              | "__edn_tuple_enum" | "__edn_tuple_extra" => {
+                if let (Some(variant), Some(extra)) = (
+                  special_data
+                    .get("__edn_enum_variant")
+                    .or_else(|| special_data.get("__edn_tuple_tag")),
+                  special_data
+                    .get("__edn_enum_extra")
+                    .or_else(|| special_data.get("__edn_tuple_extra")),
                 ) {
-                  let enum_tag = special_data.get("__edn_tuple_enum").map(|x| Arc::new(x.clone()));
+                  let type_name = special_data
+                    .get("__edn_enum_type")
+                    .or_else(|| special_data.get("__edn_tuple_enum"))
+                    .and_then(edn_symbol_name);
                   if let Edn::List(EdnListView(extra_vec)) = extra {
-                    Ok(Edn::Tuple(EdnTupleView {
-                      tag: Arc::new(tag.clone()),
-                      enum_tag,
+                    let Some(variant) = edn_symbol_name(variant) else {
+                      return Err(de::Error::custom("Invalid enum variant"));
+                    };
+                    Ok(Edn::Enum(EdnEnumView {
+                      variant,
+                      type_name,
                       extra: extra_vec.clone(),
                     }))
                   } else {
@@ -319,16 +342,19 @@ impl<'de> Deserialize<'de> for Edn {
                   Err(de::Error::custom("Invalid buffer data"))
                 }
               }
-              "__edn_record_tag" => {
-                if let Some(Edn::Str(tag_str)) = special_data.get("__edn_record_tag") {
-                  let tag = EdnTag::new(tag_str.as_ref());
+              "__edn_struct_name" | "__edn_record_tag" => {
+                if let Some(name) = special_data
+                  .get("__edn_struct_name")
+                  .or_else(|| special_data.get("__edn_record_tag"))
+                  .and_then(edn_symbol_name)
+                {
                   let mut pairs = Vec::new();
                   for (k, v) in &result_map {
                     if let Edn::Str(key_str) = k {
                       pairs.push((EdnTag::new(key_str.as_ref()), v.clone()));
                     }
                   }
-                  Ok(Edn::Record(EdnRecordView { tag, pairs }))
+                  Ok(Edn::Struct(EdnStructView { name, pairs }))
                 } else {
                   Err(de::Error::custom("Invalid record tag"))
                 }
@@ -1038,7 +1064,7 @@ impl<'de> Deserializer<'de> for EdnDeserializer {
     match self.value {
       Edn::Map(EdnMapView(map)) => visitor.visit_map(EdnMapDeserializer::new(map.into_iter())),
       // Support Record deserialization to Map/Struct by ignoring the record name
-      Edn::Record(EdnRecordView { tag: _, pairs }) => {
+      Edn::Struct(EdnStructView { name: _, pairs }) => {
         // Convert Record pairs to Map format for struct deserialization
         let mut map = HashMap::new();
         for (key, value) in pairs {
@@ -1062,7 +1088,7 @@ impl<'de> Deserializer<'de> for EdnDeserializer {
     match self.value {
       Edn::Map(EdnMapView(map)) => visitor.visit_map(EdnMapDeserializer::new(map.into_iter())),
       // Support Record deserialization to struct by ignoring the record name
-      Edn::Record(EdnRecordView { tag: _, pairs }) => {
+      Edn::Struct(EdnStructView { name: _, pairs }) => {
         // Convert Record pairs to Map format for struct deserialization
         let mut map = HashMap::new();
         for (key, value) in pairs {

--- a/tests/display_tests.rs
+++ b/tests/display_tests.rs
@@ -2,25 +2,25 @@ extern crate cirru_edn;
 
 use std::{sync::Arc, vec};
 
-use cirru_edn::{Edn, EdnListView, EdnRecordView, EdnTag};
+use cirru_edn::{Edn, EdnListView, EdnStructView, EdnTag};
 
 #[test]
 fn display_data() {
-  let r = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("Demo"),
+  let r = Edn::Struct(EdnStructView {
+    name: Arc::from("Demo"),
     pairs: vec![
       (EdnTag::new("a"), Edn::Number(1.0)),
       (EdnTag::new("a"), Edn::Number(2.0)),
     ],
   });
 
-  assert_eq!(format!("{r}"), "(%{} :Demo (:a 1) (:a 2))");
+  assert_eq!(format!("{r}"), "(%{} 'Demo (:a 1) (:a 2))");
 
-  let t = Edn::from((Arc::new(Edn::tag("t")), vec![]));
-  assert_eq!(format!("{t}"), "(:: :t)");
+  let t = Edn::from((Arc::from("t"), vec![]));
+  assert_eq!(format!("{t}"), "(:: 't)");
 
-  let t2 = Edn::from((Arc::new(Edn::tag("t")), vec![Edn::Number(1.0), Edn::Number(2.0)]));
-  assert_eq!(format!("{t2}"), "(:: :t 1 2)");
+  let t2 = Edn::from((Arc::from("t"), vec![Edn::Number(1.0), Edn::Number(2.0)]));
+  assert_eq!(format!("{t2}"), "(:: 't 1 2)");
 }
 
 #[test]

--- a/tests/edn_tests.rs
+++ b/tests/edn_tests.rs
@@ -1,9 +1,10 @@
 extern crate cirru_edn;
 
-use cirru_edn::EdnRecordView;
+use cirru_edn::EdnStructView;
 use cirru_edn::{Edn, EdnListView, EdnTag};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[test]
 fn edn_parsing() {
@@ -20,28 +21,28 @@ fn edn_parsing() {
   assert_eq!(Ok(Edn::Number(2.0)), cirru_edn::parse("do 2"));
   assert_eq!(Ok(Edn::Number(-2.2)), cirru_edn::parse("do -2.2"));
 
-  assert_eq!(Ok(Edn::tuple(Edn::tag("a"), vec![])), cirru_edn::parse(":: :a"));
+  assert_eq!(Ok(Edn::enum_value("a", vec![])), cirru_edn::parse(":: :a"));
 
   assert_eq!(
-    Ok(Edn::tuple(Edn::tag("a"), vec![Edn::Number(1.0)])),
+    Ok(Edn::enum_value("a", vec![Edn::Number(1.0)])),
     cirru_edn::parse(":: :a 1")
   );
 
   assert_eq!(
-    Ok(Edn::tuple(Edn::tag("a"), vec![Edn::Number(1.0), Edn::Number(2.0)])),
+    Ok(Edn::enum_value("a", vec![Edn::Number(1.0), Edn::Number(2.0)])),
     cirru_edn::parse(":: :a 1 2")
   );
 
   assert_eq!(
-    Ok(Edn::tuple(
-      Edn::tag("a"),
+    Ok(Edn::enum_value(
+      "a",
       vec![Edn::Number(1.0), Edn::Number(2.0), Edn::str("b")]
     )),
     cirru_edn::parse(":: :a 1 2 |b")
   );
 
   assert_eq!(
-    Ok(Edn::enum_tuple(Edn::tag("e"), Edn::tag("a"), vec![Edn::Number(1.0)])),
+    Ok(Edn::typed_enum("e", "a", vec![Edn::Number(1.0)])),
     cirru_edn::parse("%:: :e :a 1")
   );
 
@@ -101,11 +102,8 @@ fn edn_formatting() -> Result<(), String> {
   assert_eq!(cirru_edn::format(&Edn::str("a"), true)?, "\ndo |a\n");
 
   assert_eq!(
-    cirru_edn::format(
-      &Edn::enum_tuple(Edn::tag("e"), Edn::tag("a"), vec![Edn::Number(1.0)]),
-      true
-    )?,
-    "\n%:: :e :a 1\n"
+    cirru_edn::format(&Edn::typed_enum("e", "a", vec![Edn::Number(1.0)]), true)?,
+    "\n%:: 'e 'a 1\n"
   );
 
   assert_eq!(cirru_edn::format(&Edn::str("a b"), true)?, "\ndo \"|a b\"\n");
@@ -125,21 +123,18 @@ fn edn_formatting() -> Result<(), String> {
   );
 
   assert_eq!(
-    cirru_edn::format(&Edn::tuple(Edn::tag("a"), vec![Edn::Number(1.0)]), true)?,
-    "\n:: :a 1\n"
+    cirru_edn::format(&Edn::enum_value("a", vec![Edn::Number(1.0)]), true)?,
+    "\n:: 'a 1\n"
   );
 
-  assert_eq!(
-    cirru_edn::format(&Edn::tuple(Edn::tag("a"), vec![]), true)?,
-    "\n:: :a\n"
-  );
+  assert_eq!(cirru_edn::format(&Edn::enum_value("a", vec![]), true)?, "\n:: 'a\n");
 
   assert_eq!(
     cirru_edn::format(
-      &Edn::tuple(Edn::tag("a"), vec![Edn::Number(1.0), Edn::tag("c"), Edn::Nil]),
+      &Edn::enum_value("a", vec![Edn::Number(1.0), Edn::tag("c"), Edn::Nil]),
       true
     )?,
-    "\n:: :a 1 :c nil\n"
+    "\n:: 'a 1 :c nil\n"
   );
 
   Ok(())
@@ -224,8 +219,8 @@ fn demo_parsing() -> Result<(), String> {
 
   assert_eq!(
     cirru_edn::parse(RECORD_DEMO),
-    Ok(Edn::Record(EdnRecordView {
-      tag: EdnTag::new("Demo"),
+    Ok(Edn::Struct(EdnStructView {
+      name: Arc::from("Demo"),
       pairs: vec![
         (EdnTag::new("a"), Edn::Number(1.0),),
         (EdnTag::new("b"), Edn::Number(2.0)),
@@ -246,8 +241,8 @@ fn demo_parsing() -> Result<(), String> {
 
   assert_eq!(
     cirru_edn::format(
-      &Edn::Record(EdnRecordView {
-        tag: EdnTag::new("Demo"),
+      &Edn::Struct(EdnStructView {
+        name: Arc::from("Demo"),
         pairs: vec![
           (EdnTag::new("a"), Edn::Number(1.0),),
           (EdnTag::new("b"), Edn::Number(2.0)),
@@ -259,7 +254,7 @@ fn demo_parsing() -> Result<(), String> {
       }),
       false
     ),
-    Ok(String::from(RECORD_DEMO))
+    Ok(String::from("\n%{} 'Demo (:a 1)\n  :b 2\n  :c $ [] 1 2 3\n"))
   );
 
   Ok(())
@@ -380,8 +375,8 @@ fn test_string_order() -> Result<(), String> {
 
 #[test]
 fn test_format_record() -> Result<(), String> {
-  let record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("Demo"),
+  let record = Edn::Struct(EdnStructView {
+    name: Arc::from("Demo"),
     pairs: vec![
       (EdnTag::new("a"), Edn::Number(1.0)),
       (
@@ -394,11 +389,11 @@ fn test_format_record() -> Result<(), String> {
   });
   assert_eq!(
     cirru_edn::format(&record, true)?,
-    "\n%{} :Demo (:a 1) (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
+    "\n%{} 'Demo (:a 1) (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
   );
 
-  let record_unstable_order = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("Demo"),
+  let record_unstable_order = Edn::Struct(EdnStructView {
+    name: Arc::from("Demo"),
     pairs: vec![
       (
         EdnTag::new("c"),
@@ -412,7 +407,7 @@ fn test_format_record() -> Result<(), String> {
 
   assert_eq!(
     cirru_edn::format(&record_unstable_order, true)?,
-    "\n%{} :Demo (:a 1) (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
+    "\n%{} 'Demo (:a 1) (:b 2) (:d 3)\n  :c $ [] 1 2 3\n"
   );
 
   Ok(())

--- a/tests/record_deserialization_tests.rs
+++ b/tests/record_deserialization_tests.rs
@@ -5,9 +5,10 @@
 
 extern crate cirru_edn;
 
-use cirru_edn::{Edn, EdnRecordView, EdnTag, from_edn, to_edn};
+use cirru_edn::{Edn, EdnStructView, EdnTag, from_edn, to_edn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct TestPerson {
@@ -29,8 +30,8 @@ struct TestPersonWithRename {
 #[test]
 fn test_record_to_struct_basic() {
   // Create a Record with person data
-  let person_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("PersonRecord"), // This tag will be ignored
+  let person_record = Edn::Struct(EdnStructView {
+    name: Arc::from("PersonRecord"), // This tag will be ignored
     pairs: vec![
       (EdnTag::new("name"), "Alice".into()),
       (EdnTag::new("age"), Edn::Number(30.0)),
@@ -49,8 +50,8 @@ fn test_record_to_struct_basic() {
 #[test]
 fn test_record_to_struct_with_nil() {
   // Create a Record with nil email
-  let person_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("PersonRecord"),
+  let person_record = Edn::Struct(EdnStructView {
+    name: Arc::from("PersonRecord"),
     pairs: vec![
       (EdnTag::new("name"), "Bob".into()),
       (EdnTag::new("age"), Edn::Number(25.0)),
@@ -68,8 +69,8 @@ fn test_record_to_struct_with_nil() {
 #[test]
 fn test_record_to_struct_with_renamed_fields() {
   // Create a Record with hyphenated field names
-  let person_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("SpecialPersonRecord"),
+  let person_record = Edn::Struct(EdnStructView {
+    name: Arc::from("SpecialPersonRecord"),
     pairs: vec![
       (EdnTag::new("name"), "Charlie".into()),
       (EdnTag::new("age"), Edn::Number(35.0)),
@@ -99,7 +100,7 @@ fn test_struct_serializes_to_map_not_record() {
   // Struct should serialize to Map, not Record
   match edn_value {
     Edn::Map(_) => {} // This is expected
-    Edn::Record(_) => panic!("Struct should not serialize to Record"),
+    Edn::Struct(_) => panic!("Struct should not serialize to Record"),
     _ => panic!("Struct should serialize to Map"),
   }
 }
@@ -107,8 +108,8 @@ fn test_struct_serializes_to_map_not_record() {
 #[test]
 fn test_roundtrip_record_to_struct_to_map() {
   // Start with a Record
-  let original_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("PersonRecord"),
+  let original_record = Edn::Struct(EdnStructView {
+    name: Arc::from("PersonRecord"),
     pairs: vec![
       (EdnTag::new("name"), "Eve".into()),
       (EdnTag::new("age"), Edn::Number(28.0)),
@@ -131,8 +132,8 @@ fn test_roundtrip_record_to_struct_to_map() {
 #[test]
 fn test_record_ignores_tag_name() {
   // Test that different record tag names don't affect deserialization
-  let record1 = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("PersonRecord"),
+  let record1 = Edn::Struct(EdnStructView {
+    name: Arc::from("PersonRecord"),
     pairs: vec![
       (EdnTag::new("name"), "Frank".into()),
       (EdnTag::new("age"), Edn::Number(32.0)),
@@ -140,8 +141,8 @@ fn test_record_ignores_tag_name() {
     ],
   });
 
-  let record2 = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("CompleteDifferentName"),
+  let record2 = Edn::Struct(EdnStructView {
+    name: Arc::from("CompleteDifferentName"),
     pairs: vec![
       (EdnTag::new("name"), "Frank".into()),
       (EdnTag::new("age"), Edn::Number(32.0)),
@@ -165,22 +166,22 @@ fn test_record_with_complex_nested_data() {
   }
 
   // Create a Record with nested data
-  let dept_record = Edn::Record(EdnRecordView {
-    tag: EdnTag::new("DepartmentRecord"),
+  let dept_record = Edn::Struct(EdnStructView {
+    name: Arc::from("DepartmentRecord"),
     pairs: vec![
       (EdnTag::new("name"), "Engineering".into()),
       (EdnTag::new("employees"), {
         vec![
-          Edn::Record(EdnRecordView {
-            tag: EdnTag::new("PersonRecord"),
+          Edn::Struct(EdnStructView {
+            name: Arc::from("PersonRecord"),
             pairs: vec![
               (EdnTag::new("name"), "Alice".into()),
               (EdnTag::new("age"), Edn::Number(30.0)),
               (EdnTag::new("email"), "alice@example.com".into()),
             ],
           }),
-          Edn::Record(EdnRecordView {
-            tag: EdnTag::new("PersonRecord"),
+          Edn::Struct(EdnStructView {
+            name: Arc::from("PersonRecord"),
             pairs: vec![
               (EdnTag::new("name"), "Bob".into()),
               (EdnTag::new("age"), Edn::Number(25.0)),

--- a/tests/tuple_tests.rs
+++ b/tests/tuple_tests.rs
@@ -2,38 +2,38 @@ use cirru_edn::{Edn, format, parse};
 use std::sync::Arc;
 
 #[test]
-fn test_tuple_enum() {
-  let tuple = Edn::enum_tuple(Edn::tag("e"), Edn::tag("a"), vec![Edn::Number(1.0)]);
-  let expected_str = "\n%:: :e :a 1\n";
-  assert_eq!(format(&tuple, true).unwrap(), expected_str);
+fn test_enum_symbols_and_legacy_tags() {
+  let value = Edn::typed_enum("e", "a", vec![Edn::Number(1.0)]);
+  let expected_str = "\n%:: 'e 'a 1\n";
+  assert_eq!(format(&value, true).unwrap(), expected_str);
 
   let parsed = parse("%:: :e :a 1").unwrap();
-  assert_eq!(tuple, parsed);
+  assert_eq!(value, parsed);
 
-  if let Edn::Tuple(view) = parsed {
-    assert_eq!(view.enum_tag, Some(Arc::new(Edn::tag("e"))));
-    assert_eq!(view.tag, Arc::new(Edn::tag("a")));
+  if let Edn::Enum(view) = parsed {
+    assert_eq!(view.type_name, Some(Arc::from("e")));
+    assert_eq!(view.variant, Arc::from("a"));
     assert_eq!(view.extra, vec![Edn::Number(1.0)]);
   } else {
-    panic!("not a tuple");
+    panic!("not an enum");
   }
 }
 
 #[test]
-fn test_tuple_serde() {
-  let tuple = Edn::enum_tuple(Edn::tag("e"), Edn::tag("a"), vec![Edn::Number(1.0)]);
-  let edn_encoded = cirru_edn::to_edn(&tuple).unwrap();
+fn test_enum_serde() {
+  let value = Edn::typed_enum("e", "a", vec![Edn::Number(1.0)]);
+  let edn_encoded = cirru_edn::to_edn(&value).unwrap();
   let reconstructed: Edn = cirru_edn::from_edn(edn_encoded).unwrap();
-  assert_eq!(tuple, reconstructed);
+  assert_eq!(value, reconstructed);
 }
 
 #[test]
-fn test_tuple_comparison() {
-  let t1 = Edn::enum_tuple(Edn::tag("e1"), Edn::tag("a"), vec![]);
-  let t2 = Edn::enum_tuple(Edn::tag("e2"), Edn::tag("a"), vec![]);
+fn test_enum_comparison() {
+  let t1 = Edn::typed_enum("e1", "a", vec![]);
+  let t2 = Edn::typed_enum("e2", "a", vec![]);
   assert!(t1 < t2);
 
-  let t3 = Edn::tuple(Edn::tag("a"), vec![]);
+  let t3 = Edn::enum_value("a", vec![]);
   // None < Some
   assert!(t3 < t1);
 }

--- a/tests/viewer_tests.rs
+++ b/tests/viewer_tests.rs
@@ -1,18 +1,19 @@
 extern crate cirru_edn;
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
-use cirru_edn::{Edn, EdnListView, EdnMapView, EdnRecordView, EdnSetView, EdnTag};
+use cirru_edn::{Edn, EdnListView, EdnMapView, EdnSetView, EdnStructView, EdnTag};
 
 #[test]
 fn building_record() {
-  let mut record = EdnRecordView::new(EdnTag::new("a"));
+  let mut record = EdnStructView::new("a");
   record.insert("b", Edn::Number(1.0));
   record.insert("c", Edn::Number(2.0));
 
   assert_eq!(
-    Edn::Record(EdnRecordView {
-      tag: EdnTag::new("a"),
+    Edn::Struct(EdnStructView {
+      name: Arc::from("a"),
       pairs: vec![
         (EdnTag::new("b"), Edn::Number(1.0)),
         (EdnTag::new("c"), Edn::Number(2.0)),


### PR DESCRIPTION
## Summary
- rename EDN Record/Tuple values and views to Struct/Enum
- use symbols for struct names and enum type/variant names, while accepting legacy tags during parsing and serde decoding
- update documentation, examples, and tests for canonical symbol output

## Validation
- cargo fmt --check
- cargo test